### PR TITLE
Document the architecture and the issues this config had

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@
 !.zshrc
 !README.md
 !MAC.md
+!ARCHITECTURE.md
+!ISSUES.md
 !install.sh
 !.gitconfig
 !.config/i3blocks/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,228 @@
+# Architecture
+
+How this repo relates to the machine it is checked out on.
+
+The short version: **the repo is the source of truth, and it is applied as
+symlinks.** A managed path is not a copy of the repo — it *is* the repo file
+under a second name. There is no sync step and nothing can drift.
+
+## 1. Repo to `$HOME`
+
+`install.sh` reads one manifest and creates symlinks. Only the `nvim` group is
+applied by default; the rest is opt-in, because those paths either replace
+machine-specific files or are platform-specific.
+
+```mermaid
+flowchart LR
+  subgraph repo["dotfiles repo — tracked in git"]
+    direction TB
+    R1[".config/nvim/"]
+    R2[".zshrc"]
+    R3[".aliases"]
+    R4[".gitconfig"]
+    R5[".config/kitty/kitty.conf"]
+    R6[".config/i3/ + i3blocks/"]
+  end
+
+  subgraph home["$HOME — the machine"]
+    direction TB
+    H1["~/.config/nvim"]
+    H2["~/.zshrc"]
+    H3["~/.aliases"]
+    H4["~/.gitconfig"]
+    H5["~/.config/kitty/kitty.conf"]
+    H6["~/.config/i3/ + i3blocks/"]
+  end
+
+  R1 -- "nvim · default" --> H1
+  R2 -- "shell · opt-in" --> H2
+  R3 -- "shell · opt-in" --> H3
+  R4 -- "git · opt-in" --> H4
+  R5 -- "kitty · opt-in" --> H5
+  R6 -- "i3 · opt-in, Linux only" --> H6
+```
+
+Because these are symlinks, editing either side is the same write:
+
+```
+$ ls -i .config/nvim/init.lua           87297180
+$ ls -i ~/.config/nvim/init.lua         87297180   ← same inode, one file
+```
+
+Run `./install.sh --status` to see which groups are linked on this machine and
+which are still a local copy.
+
+### Adding a managed file
+
+One line in the `manifest()` function in `install.sh`:
+
+```
+group|path-in-repo|path-in-HOME
+```
+
+then `./install.sh --link-<group>`. Nothing else knows about the list, so there
+is no second place to update.
+
+## 2. Shell config: three layers
+
+`.zshrc` is the one file that mixes content which *must* be shared with content
+that must *never* be. Splitting it by destination is what makes the shared part
+safe to symlink out of a public repo.
+
+```mermaid
+flowchart TD
+  Z["~/.zshrc<br/>symlink to the repo — TRACKED, shared"]
+
+  Z --> A["source ~/.aliases<br/>TRACKED, shared"]
+  A --> P["source ~/.privatealiases<br/>UNTRACKED · mode 0600<br/>tokens and secrets"]
+  P --> D["source ~/.zshrc.d/*.zsh<br/>UNTRACKED · name order, last<br/>per-machine PATH, tools, aliases"]
+
+  style P fill:#4a2b2b,stroke:#c86464,color:#f0d0d0
+  style D fill:#2b3a4a,stroke:#6496c8,color:#d0e4f0
+```
+
+| Layer | Tracked | Holds |
+| --- | --- | --- |
+| repo `.zshrc`, `.aliases` | yes | everything genuinely shared between machines |
+| `~/.privatealiases` | **no** | tokens and secrets, mode 0600 |
+| `~/.zshrc.d/*.zsh` | **no** | per-machine PATH, tool setup, local aliases |
+
+`~/.zshrc.d` is the part that scales: machine-local config is a **new file**, not
+an edit to a shared one. Nothing to merge across machines, nothing to
+accidentally commit. Numeric prefixes control order.
+
+Secrets deliberately stay in the single `~/.privatealiases` rather than becoming
+another drop-in. One well-known path is easier to hold at 0600, exclude from
+backups and audit than one file among many in a directory that gets added to
+routinely. `--status` reports the mode of both and warns on anything readable by
+other users.
+
+## 3. What `install.sh` does
+
+Everything a config file cannot do for itself: install packages, create the
+symlinks, and prepare the Neovim python provider.
+
+```mermaid
+flowchart TD
+  S([./install.sh]) --> DETECT["detect OS and package manager<br/>brew · pacman · apt · dnf"]
+  DETECT --> PRE["check prerequisites<br/>git, a C compiler for treesitter"]
+  PRE --> DEPS["install dependencies<br/>per-distro package names<br/>retry one-by-one on failure"]
+  DEPS --> LINK["link the nvim group"]
+  LINK --> CLEAN["remove any old packer tree<br/>it would shadow lazy's copies"]
+  CLEAN --> VENV["python3 provider venv<br/>+ pynvim, for UltiSnips"]
+  VENV --> PLUG["nvim --headless '+Lazy! sync'"]
+  PLUG --> OPT{"opt-in groups<br/>requested?"}
+  OPT -- yes --> GROUPS["shell · git · kitty · i3<br/>each with its own safety check"]
+  OPT -- no --> VERIFY
+  GROUPS --> VERIFY["verify: plugins load,<br/>python3 provider imports pynvim"]
+  VERIFY --> ST["print --status"]
+```
+
+Properties worth knowing:
+
+- **Re-runnable.** Anything it would replace is moved to `<path>.backup.<n>`,
+  never deleted.
+- **`--dry-run`** prints every action without performing any.
+- **Refuses unsafe links.** `--link-shell` aborts if `~/.zshrc` still contains
+  anything token-shaped, because this repo is public and tracks `.zshrc`.
+- **bash 3.2 compatible**, which is what macOS ships. No associative arrays, no
+  `mapfile`, no `${var,,}`.
+
+## 4. Neovim
+
+Plugins are managed by [lazy.nvim](https://github.com/folke/lazy.nvim). This is
+the plugin manager, **not** LazyVim the distribution — the config is entirely
+hand-written, and adopting a distro would replace all of it.
+
+`lazy-lock.json` is tracked on purpose, so a second machine installs the same
+plugin revisions rather than whatever is current.
+
+```mermaid
+flowchart TD
+  N([nvim starts]) --> I["init.lua"]
+  I --> G["core/globals.lua<br/>providers, python3 host, is_mac / is_linux"]
+  G --> OV["core/options.vim<br/>editor options"]
+  OV --> OL["core/options.lua<br/>keymaps, and mapleader"]
+  OL --> PV["core/plugins.vim → lua/plugins.lua"]
+  PV --> B{"lazy.nvim<br/>present?"}
+  B -- no --> CLONE["git clone lazy.nvim<br/>then continue"]
+  B -- yes --> SETUP
+  CLONE --> SETUP["lazy.setup with the spec<br/>installs anything missing"]
+  SETUP --> CS["core/colorschemes.lua"]
+```
+
+Two ordering constraints that are easy to break:
+
+- **`mapleader` must be set before `lazy.setup`**, or `keys =` specs in the
+  plugin table bind to the wrong leader. That is why `options.lua` is sourced
+  before `plugins.vim`.
+- **Nothing is on the runtimepath until `lazy.setup` has run.** A top-level
+  `require` of a plugin module in `options.lua` therefore fails. Plugin modules
+  are required *inside* keymap callbacks instead, which also lets lazy defer
+  loading the plugin until first use.
+
+Eager versus lazy is a real decision per plugin, not a default:
+
+| Plugin | Load | Why |
+| --- | --- | --- |
+| `nvim-tree` | eager | its config registers the `VimEnter` autocmd that opens the tree when nvim starts on a directory |
+| `telescope` | on demand | required from inside the keymap callbacks |
+| `nvim-cmp` | `InsertEnter` | not needed until you type |
+| `nvim-lspconfig` | `BufReadPre` | not needed until a file is open |
+| `rustaceanvim` | `ft = rust` | irrelevant otherwise |
+
+The python3 provider is pinned to `stdpath("data")/venv`. Left unpinned it
+follows whichever `python3` is first on `$PATH`, so activating a conda env
+without `pynvim` in it silently breaks UltiSnips.
+
+## 5. One repo, two operating systems
+
+The Arch machine and the Mac share every tracked file. Differences are handled
+with **conditionals, never forks** — there is no `mac` branch and no duplicated
+config, so a change made on either machine is a change for both.
+
+```mermaid
+flowchart LR
+  F["one tracked file"] --> Q{"which OS?"}
+  Q -- macOS --> M["brew · open · no ibus<br/>no forced TERM<br/>skip shellcmdflag=-ic"]
+  Q -- Linux --> L["pacman/apt/dnf · xdg-open<br/>ibus · i3<br/>xsel clipboard"]
+```
+
+The mechanisms:
+
+- **Lua:** `vim.g.is_mac` / `vim.g.is_linux`, set in `core/globals.lua`.
+- **zsh:** `[[ "$OSTYPE" == darwin* ]]`, plus `command -v` guards so a missing
+  tool degrades instead of erroring.
+- **Paths:** probed, never hardcoded. conda, `GOROOT` and Homebrew are all
+  discovered rather than assumed.
+- **Packages:** `install.sh` maps generic names per manager — `fd` is `fd-find`
+  on apt and dnf, `delta` is `git-delta` everywhere, apt needs `python3-venv`
+  separately.
+
+## 6. Deliberately not managed
+
+| Path | Why |
+| --- | --- |
+| `~/.zshrc` on the Mac | still a local copy; it holds machine-specific setup that has not been split into `~/.zshrc.d` yet |
+| `~/.gitconfig` | the repo version needs `git-lfs` installed and changes `user.name` |
+| `~/.config/kitty/kitty.conf` | the Mac's own is better suited: `cmd+N` tabs rather than `alt+N`, since alt is a compose key on macOS |
+| `.config/vscode/editor.json` | not a path VS Code reads; reference copy only |
+| `.config/i3`, `i3blocks` | X11, inert on macOS |
+
+## 7. The trade-off
+
+Live means live. A `git checkout` or `git pull` in this repo changes the running
+editor **immediately** — there is no staging step, and a commit that breaks
+`init.lua` breaks nvim until it is fixed. That is the cost of having no drift,
+and the reason to keep the working tree on `main` rather than parked on a feature
+branch.
+
+One visible consequence: `lazy-lock.json` lives in the repo, so updating plugins
+with `:Lazy` leaves the repo dirty. That is intended — commit it, and the other
+machine gets the same revisions.
+
+## See also
+
+- [`MAC.md`](MAC.md) — macOS specifics and what is not linked there
+- [`ISSUES.md`](ISSUES.md) — defects found in this config and how each was fixed
+- [`.config/nvim/README.md`](.config/nvim/README.md) — Neovim setup notes

--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,212 @@
+# Issues found and fixed
+
+A record of concrete defects in this config, why each one happened, and how the
+fix was verified. Written while porting the config to macOS in July 2026, on
+Neovim 0.12.4 — but most of these were not macOS-specific at all.
+
+Kept because several fixes look arbitrary without the reason: it explains why
+`shellcmdflag` is conditional, why plugin modules are required inside callbacks,
+and why the python3 provider is pinned to a venv.
+
+---
+
+## A. Bootstrap — the config could not set up a new machine
+
+Three separate defects, all invisible on a machine that already had plugins
+installed, and all fatal on a fresh one.
+
+### A1. `init.lua` aborted before the plugin manager could bootstrap
+
+`init.lua` called `require("ibl").setup()` — indent-blankline, a *plugin* —
+before sourcing `plugins.vim`, which is what installs plugins. On a machine with
+no plugins the require raised, `init.lua` stopped there, and the plugin manager
+was never reached. The next launch failed identically.
+
+```mermaid
+flowchart TD
+  subgraph before["before — deadlock"]
+    B1([nvim starts]) --> B2["init.lua"]
+    B2 --> B3["require ibl"]
+    B3 --> B4["ERROR: module not found"]
+    B4 --> B5["init.lua aborts"]
+    B5 --> B6["plugins.vim never sourced<br/>→ no plugin manager<br/>→ no plugins, ever"]
+    style B4 fill:#4a2b2b,stroke:#c86464,color:#f0d0d0
+    style B6 fill:#4a2b2b,stroke:#c86464,color:#f0d0d0
+  end
+
+  subgraph after["after"]
+    A1([nvim starts]) --> A2["init.lua"]
+    A2 --> A3["source core files<br/>incl. plugins.vim"]
+    A3 --> A4["lazy.nvim bootstraps<br/>and installs everything"]
+    A4 --> A5["ibl configured by its own spec"]
+    style A4 fill:#2b4a32,stroke:#64c878,color:#d0f0d8
+  end
+```
+
+`core/options.lua` had the same shape: a top-level
+`require('telescope.builtin')`.
+
+**Verified** by running the pre-fix revision under an isolated `NVIM_APPNAME`: it
+dies at `init.lua:23` and never clones the plugin manager. Confirmed 0 plugins
+installed.
+
+**Fixed** by configuring indent-blankline through its plugin spec instead, and by
+requiring plugin modules inside keymap callbacks rather than at file scope. The
+latter is also what lets lazy.nvim defer loading.
+
+### A2. `fresh_install` was computed and never used
+
+`packer_ensure_install()` returned a flag saying "this is a first run", assigned
+it to `local fresh_install`, and nothing ever read it. So even once packer had
+been cloned, the first launch installed **no plugins** — you had to know to run
+`:PackerSync` by hand.
+
+Wiring the flag up to `packer.sync()` then exposed a second problem: the
+config's own sync raced `install.sh`'s `:PackerSync`, and neither completed.
+
+**Fixed** by migrating to lazy.nvim, which installs missing plugins during
+`setup()` with no separate step and no race.
+
+**Verified** on an isolated `HOME`: a single `nvim` launch installs all 25
+plugins. The same test under packer produced 0.
+
+### A3. `PackerSync` deleted packer itself
+
+packer was not listed in its own plugin spec, so `PackerClean` — which
+`PackerSync` runs — treated it as an unmanaged plugin and removed it. Every
+following startup re-cloned it.
+
+**Fixed** by the lazy.nvim migration; lazy manages itself.
+
+---
+
+## B. Neovim 0.12 removed APIs this config used
+
+Deprecated for several releases, but removed by the time this was run, so each
+one was a hard error or a traceback on every startup.
+
+| API | Status | Replacement |
+| --- | --- | --- |
+| `vim.pretty_print` | **gone** in 0.12 | `vim.print` |
+| `vim.diagnostic.goto_prev` / `goto_next` | **gone** in 0.12 | `vim.diagnostic.jump { count = ±1 }` |
+| `lspconfig.<server>.setup` framework | deprecated, prints a traceback | `vim.lsp.config` + `vim.lsp.enable` |
+| `vim.lsp.with` | deprecated | pass opts to `vim.lsp.buf.hover` |
+| `lspconfig.tsserver` | renamed | `lspconfig.ts_ls` |
+| `float.source = "always"` | string form dropped | `source = true` |
+
+Confirmed empirically rather than from release notes:
+`vim.pretty_print ~= nil` is `false` on 0.12.4 while `vim.print` exists.
+
+All of it is **version-gated**, not replaced outright, so an older Neovim on the
+Arch box still takes the old path:
+
+```lua
+local use_native_lsp = vim.lsp.config ~= nil and vim.lsp.enable ~= nil
+```
+
+The lspconfig migration also changed how `custom_attach` runs: the builtin API
+has no `on_attach`, so it is now driven by an `LspAttach` autocmd.
+
+---
+
+## C. Portability — Arch assumptions that break on macOS
+
+| Assumption | Effect on macOS | Fix |
+| --- | --- | --- |
+| `xdg-open` for the search-under-cursor map | command not found | `open` when `vim.g.is_mac` |
+| `shellcmdflag = '-ic'` | every `:!` re-runs the whole zsh profile — brew, conda, nvm, starship, zinit | skipped on macOS; it exists for vim-forgit, which is commented out |
+| `ibus-daemon -drx` | errors on every shell start; ibus is X11 | Linux-only branch |
+| `export TERM=rxvt` | wrong terminfo in Terminal.app, iTerm2, kitty; follows you over ssh and tmux | only when the terminal did not identify itself *and* the terminfo entry exists |
+| conda at `/opt/miniconda3` and `/home/kai/miniconda3` | neither exists; macOS is `/Users/kai` | probe a list of prefixes |
+| `GOROOT=/usr/lib/go` | Homebrew uses its own prefix | `go env GOROOT` when `go` is present |
+| no `/opt/homebrew/bin` on `PATH` | every brew-installed tool missing | `brew shellenv` first, on darwin |
+| `alias pbcopy='xsel …'` | **shadows the real `pbcopy`**, and `xsel` is X11-only, so every clipboard pipe breaks silently | only alias when `xsel` actually exists |
+| `tr -dc` over `/dev/urandom` | BSD `tr` aborts with "Illegal byte sequence" | `LC_ALL=C tr` |
+| `/home/$USER` in `rls` | macOS users live under `/Users` | `$HOME` |
+
+`clipboard=unnamedplus` needed no change — Neovim finds `pbcopy` on its own.
+
+---
+
+## D. Correctness
+
+### D1. Trailing-whitespace autocmd failed on read-only buffers
+
+```lua
+vim.api.nvim_create_autocmd({ "BufWritePre" }, {
+  pattern = { "*" },
+  command = [[%s/\s\+$//e]],
+})
+```
+
+Any write to a non-modifiable buffer raised
+`E21: Cannot make changes, 'modifiable' is off`. Hit for real by writing
+`:checkhealth` output to a file.
+
+The substitution also clobbered the search register and cursor position on every
+save.
+
+**Fixed** with a callback that returns early on `nomodifiable`/`readonly`, uses
+`keeppatterns`, and restores the view with `winsaveview`/`winrestview`.
+**Verified** both ways: writing `:checkhealth` output now succeeds, and a file
+with trailing whitespace still shrinks 16 → 12 bytes on save.
+
+### D2. UltiSnips broke depending on `$PATH`
+
+`vim.g.python3_host_prog = fn.exepath("python3")` resolves to whatever comes
+first on `$PATH`. On this Mac that is conda's python, which has no `pynvim`, so
+UltiSnips failed at startup with "Failed to load python3 host" — and it would
+break again on any conda env switch.
+
+**Fixed** by pinning the provider to `stdpath("data")/venv`, falling back to the
+old behaviour when that venv is absent so the Arch box is unaffected.
+
+Homebrew's python 3.14 could not create the venv — `ensurepip` fails — so
+`install.sh` tries several interpreters rather than assuming `python3` works.
+
+---
+
+## E. Secrets
+
+Six `export` lines in `~/.zshrc` held GitHub, Datadog and Cloudflare
+credentials. Findings, in order of how much they mattered:
+
+1. **`~/.zshrc` was mode `0644`** — world readable. Every token in it was
+   readable by any local user or process. This was the real exposure, and it had
+   nothing to do with git.
+2. **The 6 exports were only 3 distinct secrets**, each duplicated under two
+   names: `GH_TOKEN`/`NPM_TOKEN`, `DD_TOKEN`/`DD_PAT`, `CF_TOKEN`/`CF_API_TOKEN`.
+3. **One token was also in `~/.zsh_history`**, from having been typed on a
+   command line.
+4. **Nothing ever reached GitHub.** All values were checked against every commit
+   on every ref — 1.86 MB of diffs across 15 refs including 8 remote branches
+   and a tag — and against all 381 tracked files. No match, and no token-shaped
+   string anywhere in history. The repo tracks its *own* `.zshrc`, which is a
+   different file from the live `~/.zshrc` and never held a credential.
+
+**Fixed** by moving the exports to `~/.privatealiases` at mode 0600, sourced by
+`.zshrc`; tightening `~/.zshrc` to 0600; and adding `~/.zshrc.d` so
+machine-local config has a home that is not the tracked file. `install.sh
+--link-shell` now refuses to link while `~/.zshrc` contains anything
+token-shaped, and `--status` warns about loose permissions on either path.
+
+A 0600 file is a floor, not a goal — the values are still plaintext at rest and
+still in the environment of every child process. Stronger options, in
+`ARCHITECTURE.md` terms: `direnv` for project-scoped tokens, or the OS keystore
+(`security` on macOS, `secret-tool`/`pass` on Linux).
+
+---
+
+## F. Conflicts left unresolved on purpose
+
+Not bugs — cases where the machine's own file was the better one. See
+[`MAC.md`](MAC.md).
+
+- **`kitty.conf`**: the repo binds `alt+N` for tabs, but alt is a compose key on
+  macOS; the Mac's own config uses `cmd+N`. The repo version also `include`s a
+  `theme.conf` that is gitignored and absent, and hardcodes `/usr/bin/fzf` where
+  Homebrew installs to `/opt/homebrew/bin/fzf`.
+- **`.gitconfig`**: sets `core.pager = delta` and `filter.lfs.required = true`.
+  Without `git-lfs` installed, LFS repos fail to check out.
+- **`.config/vscode/editor.json`**: not a path VS Code reads. Real location is
+  `~/Library/Application Support/Code/User/settings.json`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,62 @@
-### 1.Introduction
+# dotfiles
 
-### 2.Setup
-- ZSH and Oh My ZSH
+Neovim, zsh and terminal config, shared between an Arch Linux desktop and a macOS
+laptop from a single tracked source.
+
+## Quick start
+
+```bash
+git clone https://github.com/bugb/dotfiles.git
+cd dotfiles
+./install.sh              # dependencies, symlinks, Neovim plugins
+./install.sh --with-lsp   # and the language servers
+./install.sh --status     # what is linked on this machine
+./install.sh --dry-run    # show every action, change nothing
+```
+
+Works on macOS (Homebrew), Arch (pacman), Debian/Ubuntu (apt) and Fedora (dnf).
+Re-runnable; anything it would replace is backed up rather than deleted.
+
+By default only Neovim is applied. Shell, git, kitty and i3 are opt-in
+(`--link-shell`, `--link-git`, `--link-kitty`, `--link-i3`, or `--all`) because
+they replace files that are often machine-specific.
+
+## How it works
+
+The repo is the source of truth and is applied as **symlinks**, so a managed path
+*is* the file in this repo — edit either side, there is no copy to keep in sync.
+
+Machine-specific config goes in `~/.zshrc.d/*.zsh` and secrets in
+`~/.privatealiases` (mode 0600). Neither is tracked, which is what keeps the
+shared `.zshrc` safe to symlink out of a public repo.
+
+Full detail, with diagrams: **[ARCHITECTURE.md](ARCHITECTURE.md)**.
+
+## Contents
+
+| Path | What |
+| --- | --- |
+| `.config/nvim/` | Neovim config, plugins via [lazy.nvim](https://github.com/folke/lazy.nvim) |
+| `.zshrc`, `.aliases` | zsh setup and shared aliases |
+| `.gitconfig` | git, with delta as the pager |
+| `.config/kitty/` | terminal |
+| `.config/i3/`, `.config/i3blocks/` | window manager, Linux only |
+| `install.sh` | the installer |
+
+## Docs
+
+- **[ARCHITECTURE.md](ARCHITECTURE.md)** — the symlink model, the three shell
+  config layers, install flow, Neovim load order, how one repo serves two OSes
+- **[ISSUES.md](ISSUES.md)** — defects found in this config and how each was
+  fixed, including the bootstrap deadlock and the Neovim 0.12 API removals
+- **[MAC.md](MAC.md)** — macOS specifics and what is deliberately not linked there
+- **[.config/nvim/README.md](.config/nvim/README.md)** — Neovim setup notes
+
+## Notes
+
+Plugin revisions are pinned in `lazy-lock.json`, which is tracked, so a second
+machine installs the same versions. Updating plugins with `:Lazy` leaves the repo
+dirty by design — commit the lockfile.
+
+Because the config is symlinked live, a `git pull` here changes the running editor
+immediately. There is no apply step, and no staging step either.


### PR DESCRIPTION
The repo had no explanation of how it reaches the machine, and several fixes from the macOS port look arbitrary without their reasoning. Both were only in one person's head.

## ARCHITECTURE.md

Five mermaid diagrams, which GitHub renders inline:

1. **Repo to `$HOME`** — which groups are linked by default and which are opt-in.
2. **The three shell config layers** — tracked `.zshrc` / untracked `~/.privatealiases` / untracked `~/.zshrc.d/*.zsh`, and their load order. This is what makes a public `.zshrc` safe to symlink at all.
3. **Install flow** — detect, deps, link, packer cleanup, provider venv, plugin sync, verify.
4. **Neovim load order** — including the two ordering constraints that are easy to break: `mapleader` must be set before `lazy.setup`, and nothing is on the runtimepath until `lazy.setup` has run.
5. **One repo, two OSes** — conditionals rather than a fork.

Also documents the eager-versus-lazy decision per plugin (why `nvim-tree` must stay eager, why telescope can defer), and the central trade-off: the config is live, so a `git pull` changes the running editor immediately.

## ISSUES.md

The defects found while porting, grouped by bootstrap, Neovim 0.12 API removals, portability, correctness and secrets.

Each entry records **how it was verified**, not just what changed, since that is the part that is hard to reconstruct later:

- packer's bootstrap dies at `init.lua:23` on a fresh machine and never clones the plugin manager — reproduced under an isolated `NVIM_APPNAME`
- a single `nvim` launch now installs all 25 plugins, where packer installed none
- `vim.pretty_print` is genuinely absent on 0.12.4, checked rather than assumed
- the trailing-whitespace autocmd raised `E21` on read-only buffers, hit by writing `:checkhealth` output

It also explains fixes whose motivation is invisible from the diff — why `shellcmdflag` is conditional, why plugin modules are required inside callbacks, why the python3 provider is pinned to a venv.

The secrets section records that **no credential ever reached this repo**: all values checked against every commit on every ref, 1.86 MB of diffs across 15 refs, plus all 381 tracked files. The real exposure was `~/.zshrc` at mode `0644` locally, which had nothing to do with git.

## README.md

An actual entry point rather than two empty headings.

## Note

New root files are added to the `.gitignore` whitelist. The pattern here is allowlist-style, so an unlisted root file is silently ignored — that already caught `install.sh` once.

Verified: all 6 mermaid blocks pass a structural check, and every internal doc link resolves to a file that exists.